### PR TITLE
vscode setting for rls

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "rust.build_bin": "*"
+}


### PR DESCRIPTION
저의 경우엔 저 설정 한줄을 추가해야 RLS가 src/bin 파일 안에 있는 파일들도 정상적으로 읽어서 동작하는 것 같았습니다.
